### PR TITLE
add racer data from google sheet

### DIFF
--- a/src/hooks/useGoogleSheets.js
+++ b/src/hooks/useGoogleSheets.js
@@ -29,7 +29,7 @@ function useGoogleSheets(sheetId, range) {
     };
 
     if (sheetId) fetchData();
-  }, [sheetId]);
+  }, [sheetId, range]);
 
   return { data, loading, error };
 }

--- a/src/hooks/useGoogleSheets.js
+++ b/src/hooks/useGoogleSheets.js
@@ -1,0 +1,37 @@
+import { useEffect, useState } from "react";
+
+const API_KEY = process.env.REACT_APP_GOOGLE_SHEETS_API_KEY;
+
+function useGoogleSheets(sheetId, range) {
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(null);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    const url = `https://sheets.googleapis.com/v4/spreadsheets/${sheetId}/values/${range}?key=${API_KEY}`;
+  
+    const fetchData = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const response = await fetch(url);
+        if (!response.ok) {
+          throw new Error("Failed to fetch data");
+        }
+        const result = await response.json();
+
+        setData(result.values);
+      } catch (error) {
+        setError(error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    if (sheetId) fetchData();
+  }, [sheetId]);
+
+  return { data, loading, error };
+}
+
+export default useGoogleSheets;

--- a/src/pages/RaceInformationPage.js
+++ b/src/pages/RaceInformationPage.js
@@ -1,11 +1,61 @@
-import React from "react";
+import React, { useMemo }  from "react";
+import Breadcrumb from "../components/Breadcrumb";
 import Container from "@mui/material/Container";
-import UnderConstruction from "../components/UnderConstruction";
+import useGoogleSheets from "../hooks/useGoogleSheets";
+import LoadingSpinner from "../components/LoadingSpinner";
+import Typography from "@mui/material/Typography";
 
 const RaceInformationPage = () => {
+
+  const SHEET_ID = process.env.REACT_APP_GOOGLE_SHEET_RACING_INFO_ID;
+  const RANGE = "Sheet1!A:C"; // Adjust range based on racer data (e.g., A:C for 3 columns)
+
+  const { data: sheetsData, loading, error } = useGoogleSheets(SHEET_ID, RANGE);
+  const groupedCategories = useMemo(() => {
+    if (sheetsData) {
+      const data = sheetsData.slice(1).map(([category, racer, team]) => ({ category, racer: { name: racer, team: team} })); //remove header row
+      
+      // Group racers by category
+      const grouped = data.reduce((acc, { category, racer }) => {
+        if (!acc[category]) acc[category] = [];
+        acc[category].push(racer);
+        return acc;
+      }, {});
+
+      // Convert to an array format
+      return Object.entries(grouped).map(([name, racers], id) => ({
+        id,
+        name,
+        racers,
+      }));
+    }
+  }, [sheetsData]);
+
   return (
     <Container sx={{ mt: 2 }}>
-      <UnderConstruction />
+      <Breadcrumb name={"Racing Info"} />
+      {loading ? (
+        <LoadingSpinner />
+      ) : error ? (
+        <Typography>
+          Error loading racing data, please check back later.
+        </Typography>
+      ) : !groupedCategories || groupedCategories.length === 0 ? (
+        <Typography>
+          There are currently no racers available to be shown.
+        </Typography>
+      ) : (
+        groupedCategories.map((category) => (
+          <div key={category.id} style={{ marginBottom: "20px" }}>
+          <h2>{category.name}</h2>
+          <ul>
+            {category.racers.map((racer, index) => (
+              <li key={index}>{racer.name} {(racer.team) ? "[" + racer.team + "]" : "" }</li>
+            ))}
+          </ul>
+        </div>
+        ))
+      )}
     </Container>
   );
 };


### PR DESCRIPTION
Racing page pulls data from this Google Sheet that has a list of some of the racers who have purchased tickets.

https://docs.google.com/spreadsheets/d/1b04PyTyJzrf-PfHEEarWv8p77zBOsztkzRM4fVAhZLw/edit?usp=sharing

Currently the sheet is viewable by anyone with link.  I'll create an issue to secure this so that a service account is granted access to limit access.

New environment variables need to be add to Netlify by @jfarago (I will send these in an email).
